### PR TITLE
use scrollable container because not everyone has a large screen

### DIFF
--- a/src/tuitka/widgets/script_input.py
+++ b/src/tuitka/widgets/script_input.py
@@ -1,6 +1,6 @@
 from textual import on
 from textual.app import ComposeResult
-from textual.containers import Vertical, Center, Container
+from textual.containers import ScrollableContainer, Vertical, Center
 from textual.widgets import Button, Input, Static
 from textual.widgets import RadioButton, RadioSet
 from tuitka.constants import PYTHON_VERSION
@@ -28,7 +28,7 @@ class ScriptInput(Input):
         self.app.script = Path(self.value.strip())
 
 
-class ScriptInputWidget(Container):
+class ScriptInputWidget(ScrollableContainer):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         self.custom_settings = None


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Make ScriptInputWidget scrollable by changing its base class to ScrollableContainer