### PR TITLE
fix some static type checker issues

### DIFF
--- a/src/tuitka/__init__.py
+++ b/src/tuitka/__init__.py
@@ -1,4 +1,5 @@
 import sys
+from tuitka.constants import PYTHON_VERSION
 from tuitka.tui import NuitkaTUI
 from pathlib import Path
 from tuitka.utils import chdir_context, error
@@ -23,7 +24,7 @@ def main() -> None:
         }
 
         with chdir_context(path.parent):
-            inline_app = InlineCompilationApp(path, **default_options)
+            inline_app = InlineCompilationApp(path, python_version=PYTHON_VERSION, **default_options)
             inline_app.run(inline=True)
             return
 

--- a/src/tuitka/utils.py
+++ b/src/tuitka/utils.py
@@ -21,11 +21,7 @@ def error(message: str, title: str = "Error", subtitle: Optional[str] = None):
     from rich import print
     from rich.panel import Panel
 
-    panel_kwargs = {"title": title, "border_style": "red"}
-    if subtitle:
-        panel_kwargs["subtitle"] = subtitle
-
-    print(Panel.fit(message, **panel_kwargs))
+    print(Panel.fit(message, title=title, border_style="red", subtitle=subtitle))
 
 
 @contextmanager
@@ -216,7 +212,7 @@ def prepare_nuitka_command(
     dependencies_metadata = parse_dependencies(script_path)
     original_is_standalone = nuitka_options.get("--standalone", False)
     original_is_onefile = nuitka_options.get("--onefile", False)
-    
+
     if platform_name == "darwin":
         if original_is_onefile or original_is_standalone:
             nuitka_options.pop("--onefile", None)

--- a/src/tuitka/widgets/modals/compilation.py
+++ b/src/tuitka/widgets/modals/compilation.py
@@ -21,6 +21,7 @@ class CompilationScreen(ModalScreen):
 
     def __init__(self, python_version: str = PYTHON_VERSION, **nuitka_options) -> None:
         self.cwd = Path.cwd()
+        assert hasattr(self.app, "script") and isinstance(self.app.script, Path)
         os.chdir(self.app.script.parent)
         super().__init__()
         self.python_version = python_version
@@ -30,6 +31,7 @@ class CompilationScreen(ModalScreen):
         self.deps_metadata = None
 
     def compose(self) -> ComposeResult:
+        assert hasattr(self.app, "script") and isinstance(self.app.script, Path)
         self.nuitka_command, self.deps_metadata = prepare_nuitka_command(
             self.app.script, self.python_version, **self.nuitka_options
         )

--- a/src/tuitka/widgets/modals/settings.py
+++ b/src/tuitka/widgets/modals/settings.py
@@ -1,6 +1,7 @@
 from textual import on
 from textual.app import ComposeResult
 from textual.containers import Horizontal, ScrollableContainer
+from textual.css.query import DOMQuery
 from textual.screen import ModalScreen
 from textual.widgets import Button, Collapsible, Input, Static
 
@@ -124,10 +125,15 @@ class NuitkaSettingsScreen(ModalScreen[dict | None]):
 
     def filter_settings(self, search_term: str) -> None:
         query_selector = (
-            "ModalBoolFlag, ModalStringFlag, ModalSelectionFlag, ModalRadioFlag"
+            ModalBoolFlag,
+            ModalStringFlag,
+            ModalSelectionFlag,
+            ModalRadioFlag,
         )
-        all_widgets = self.query(query_selector)
-        all_collapsibles = self.query(Collapsible)
+        all_widgets: list[ModalBoolFlag | ModalStringFlag | ModalSelectionFlag | ModalRadioFlag] = []
+        for selector in query_selector:
+            all_widgets.extend(self.query(selector))
+        all_collapsibles: DOMQuery[Collapsible] = self.query(Collapsible)
 
         if not search_term:
             for widget in all_widgets:

--- a/src/tuitka/widgets/modals/splash.py
+++ b/src/tuitka/widgets/modals/splash.py
@@ -73,8 +73,8 @@ class SplashScreen(ModalScreen):
         self.char_index += 1
 
     def get_random_offset(self, magnitude: float = 15.0) -> Offset:
-        x_offset = uniform(-magnitude, magnitude)
-        y_offset = uniform(-magnitude * 0.4, magnitude * 0.4)
+        x_offset = int(uniform(-magnitude, magnitude))
+        y_offset = int(uniform(-magnitude * 0.4, magnitude * 0.4))
         return Offset(x_offset, y_offset)
 
     def dismiss_splash(self) -> None:

--- a/src/tuitka/widgets/script_input.py
+++ b/src/tuitka/widgets/script_input.py
@@ -15,9 +15,9 @@ from tuitka.widgets.modals import (
 
 
 class ScriptInput(Input):
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self) -> None:
         super().__init__(
-            placeholder="Enter path to Python script to compile", *args, **kwargs
+            placeholder="Enter path to Python script to compile", id="script_input"
         )
 
     def on_mount(self) -> None:
@@ -25,7 +25,7 @@ class ScriptInput(Input):
 
     def on_input_changed(self, event: Input.Changed) -> None:
         """Update app script when input changes."""
-        self.app.script = Path(self.value.strip())
+        setattr(self.app, "script", Path(self.value.strip()))
 
 
 class ScriptInputWidget(Container):
@@ -144,7 +144,7 @@ class ScriptInputWidget(Container):
             )
 
             with Vertical(id="input_section"):
-                yield ScriptInput(id="script_input")
+                yield ScriptInput()
                 with Center():
                     yield Button("Browse Files", variant="primary", id="browse_button")
 
@@ -237,7 +237,7 @@ class ScriptInputWidget(Container):
     def _handle_file_selection(self, selected_file: str | None) -> None:
         if selected_file:
             self.query_one("#script_input", ScriptInput).value = selected_file
-            self.app.script = selected_file
+            setattr(self.app, "script", selected_file)
             self.query_one("#compilation_options_container").display = True
 
     def _handle_custom_settings(self, settings: dict | None) -> None:


### PR DESCRIPTION
i didnt really get to everything, just resolved whatever ty screamed at me for

## Summary by Sourcery

Resolve static type checker errors by adding type annotations, assertions, and refactoring method signatures and attribute assignments

Enhancements:
- Refactor filter_settings to iterate over typed selectors and annotate the resulting widget lists
- Update ScriptInput to use an explicit init signature, remove variadic args, and assign app.script via setattr
- Simplify the error panel print call by inlining Panel.fit kwargs
- Convert splash screen random offsets to integers
- Pass python_version to InlineCompilationApp and assert the type of app.script in CompilationScreen

Chores:
- Remove trailing whitespace and streamline kwargs construction